### PR TITLE
Unbreak shared memory on FreeBSD

### DIFF
--- a/src/outputs.c
+++ b/src/outputs.c
@@ -36,6 +36,7 @@
 #include <stdarg.h>
 
 #include <sys/mman.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -190,7 +191,7 @@ static int create_shm_file(size_t size, const char *fmt, ...) {
     return -1;
   }
 
-  fd = shm_open(shm_name, O_CREAT | O_RDWR, 0);
+  fd = shm_open(shm_name, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR);
   if (fd == -1) {
     fprintf(stderr, "shm_open: %s\n", strerror(errno));
     free(shm_name);


### PR DESCRIPTION
`shm_open` with `O_CREAT` uses `mode` for desired permissions. Linux ignores `mode == 0` as unset.
https://pubs.opengroup.org/onlinepubs/9699919799/functions/shm_open.html

```c
$ cat a.c
#include <sys/mman.h>
#include <fcntl.h>
#include <err.h>

int main()
{
  char *shm_name = "/test";
  if (shm_open(shm_name, O_CREAT | O_RDWR, 0) == -1)
    err(1, "shm_open(%s)", shm_name);
  if (shm_unlink(shm_name) == -1)
    err(1, "shm_unlink(%s)", shm_name);
  return 0;
}

$ cc a.c
$ umask
022
$ ./a.out
a.out: shm_unlink(/test): Permission denied
$ ./a.out
a.out: shm_open(/test): Permission denied
$ posixshmcontrol ls
MODE            OWNER   GROUP   SIZE    PATH
---------       foo     foo     0       /test
$ posixshmcontrol rm /test
$ ./a.out
a.out: shm_unlink(/test): Permission denied
```
