### PR TITLE
use gsettings

### DIFF
--- a/resources/meson.build
+++ b/resources/meson.build
@@ -40,6 +40,16 @@ if scour.found()
 install_data(icon, install_dir: icondir)
   endif
 
+gnome.compile_schemas(
+  build_by_default: true,
+  depend_files: 'network.cycles.wdisplays.gschema.xml'
+)
+
+install_data(
+  'network.cycles.wdisplays.gschema.xml',
+  install_dir: join_paths(get_option('datadir'), 'glib-2.0', 'schemas')
+)
+
 install_data(
     configure_file(input: 'wdisplays.desktop.in',
       output: '@0@.desktop'.format(meson.project_name()),

--- a/resources/network.cycles.wdisplays.gschema.xml
+++ b/resources/network.cycles.wdisplays.gschema.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist gettext-domain="gsettings-desktop-schemas">
+ <schema id="network.cycles.wdisplays" path="/network/cycles/wdisplays/">
+    <key type="b" name="overlay">
+      <default>true</default>
+      <description>If an overlay is show on each display.</description>
+    </key>
+    <key type="b" name="capture">
+      <default>false</default>    
+      <description>If the display contents are drawn as preview.</description>
+    </key>
+    <key type="b" name="auto-apply">
+      <default>false</default>
+      <description>If the display contents are drawn as preview.</description>
+    </key>
+  </schema>
+</schemalist>


### PR DESCRIPTION
uses gsettings to store options namely screen overlay, capture and auto-apply

There is no irc channel or other place to discuss things I have the plan to 
improve the UX of wdisplays

Please let me know if the following things align with your goals 
for wdisplays or if I should continue this in a fork:
1) Remove the tab applet selecting which display to configure
since it is redundant with clicking on the rectangle for it.

2) Replace in the outputs rectangle (where you drag n' drop) the text
from output connector name with 2 lines => output->manufacturer and output->model

3) Move the Description text field to the top, make it an expandable text field for details (serial number etc, collapsed it shows only model) and move the enabled text box next to it.

4) Make an option for expert settings where the current settings with -+ boxes for resolution and refresh rate
and by default only show the menu to select a different mode

5) Remove the flipped checkbox and merge the flipped variants into the transform sub-menu


